### PR TITLE
feat: add default jenkins config as a service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG RELEASE=1
 USER root
 
 COPY files/jenkins_wrapper.sh /usr/local/bin/jenkins_wrapper.sh
+COPY files/jenkins.yaml  /usr/local/bin/jenkins.yaml
+
+ENV CASC_JENKINS_CONFIG=/usr/local/bin/jenkins.yaml
 
 # create version files to ensure Jenkins does not prompt for setup
 # allow slave to master control - https://wiki.jenkins.io/display/JENKINS/Slave+To+Master+Access+Control

--- a/files/base-plugins.txt
+++ b/files/base-plugins.txt
@@ -3,3 +3,4 @@ github
 github-oauth
 matrix-auth
 role-strategy
+configuration-as-code

--- a/files/jenkins.yaml
+++ b/files/jenkins.yaml
@@ -1,0 +1,91 @@
+jenkins:
+  agentProtocols:
+  - "JNLP4-connect"
+  - "Ping"
+  authorizationStrategy:
+    roleBased:
+      roles:
+        global:
+        - assignments:
+          - "Jenkins*Admins"
+          - ${GHE_ADMIN}
+          - ${JENKINS_ACL_MEMBERS_admin}
+          name: "admin"
+          pattern: ".*"
+          permissions:
+          - "Overall/Administer"
+        - assignments:
+          - "anonymous"
+          name: "anonymous"
+          pattern: ".*"
+          permissions:
+          - "Job/Discover"
+        - assignments:
+          - "authenticated"
+          name: "authenticated"
+          pattern: ".*"
+          permissions:
+          - "Overall/Read"
+          - "Job/Discover"
+          - "Job/Read"
+          - "Job/Workspace"
+          - "View/Read"
+        - assignments: 
+          - ${JENKINS_ACL_MEMBERS_developer}
+          name: "developer"
+          pattern: ".*"
+          permissions:
+          - "Job/Move"
+          - "Job/Build"
+          - "Job/Create"
+          - "View/Create"
+          - "Job/Discover"
+          - "Job/Read"
+          - "Run/Delete"
+          - "Job/Cancel"
+          - "Overall/Read"
+          - "Run/Update"
+          - "Job/Delete"
+          - "View/Delete"
+          - "Job/Configure"
+          - "Job/Workspace"
+          - "View/Read"
+          - "View/Configure"
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: true
+  disableRememberMe: false
+  disabledAdministrativeMonitors:
+  - "jenkins.slaves.DeprecatedAgentProtocolMonitor"
+  - "jenkins.CLI"
+  labelAtoms:
+  - name: "chef"
+  - name: "linux"
+  - name: "master"
+  markupFormatter: "plainText"
+  mode: NORMAL
+  myViewsTabBar: "standard"
+  numExecutors: 0
+  primaryView:
+    all:
+      name: "all"
+  projectNamingStrategy: "standard"
+  quietPeriod: 5
+  remotingSecurity:
+    enabled: true
+  scmCheckoutRetryCount: 0
+  securityRealm:
+    github:
+      clientID: ${GHE_KEY}
+      clientSecret: ${GHE_SECRET}
+      githubApiUri: ${GHE_API_URL}
+      githubWebUri: ${GHE_WEB_URL}
+      oauthScopes: "read:org,user:email"
+  updateCenter:
+    sites:
+    - id: "default"
+      url: "https://updates.jenkins.io/update-center.json"
+  views:
+  - all:
+      name: "all"
+  viewsTabBar: "standard"


### PR DESCRIPTION
adds in `Configuration as a service` plugin to the base plugins to enable simplified master provisioning.

https://plugins.jenkins.io/configuration-as-code/
